### PR TITLE
fix: add params into auth.py for logging in

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -28,6 +28,12 @@ oauth.register(
 @router.get("/login")
 async def login(request: Request, c: str = None):
     redirect_uri = request.url_for('auth_callback')
+    params = {
+        'scope': 'https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/calendar.readonly',
+        'access_type': 'offline',
+        'include_granted_scopes': 'true',
+        'response_type': 'code'
+    }
     if c:
         state_str = urlencode({"c": c})
         return await oauth.google.authorize_redirect(
@@ -36,7 +42,7 @@ async def login(request: Request, c: str = None):
             state=state_str
         )
 
-    return await oauth.google.authorize_redirect(request, redirect_uri)
+    return await oauth.google.authorize_redirect(request, redirect_uri, **params)
 
 @router.get("/callback")
 async def auth_callback(request: Request, db: Session = Depends(database.get_db)):


### PR DESCRIPTION
## **Key Changes:** 

- auth.py 
add params to fix OAuth 2.0 Policy (https://developers.google.com/identity/protocols/oauth2/web-server#sample-oauth-2.0-server-response)

```python
https://accounts.google.com/o/oauth2/v2/auth?
 scope=https%3A//www.googleapis.com/auth/drive.metadata.readonly%20https%3A//www.googleapis.com/auth/calendar.readonly&
 access_type=offline&
 include_granted_scopes=true&
 response_type=code&
 state=state_parameter_passthrough_value&
 redirect_uri=https%3A//oauth2.example.com/code&
 client_id=client_id
```


https://github.com/user-attachments/assets/4e08bfa6-244f-49c3-8ce3-8a66751f5d9a




